### PR TITLE
Internal 41 - Library Updates PR

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -14,7 +14,7 @@
  * language governing permissions and limitations under the License.
  */
 
-project(group: "com.inversoft.cleanspeak", name: "cleanspeak-containers", version: "3.33.0", licenses: ["ApacheV2_0"]) {
+project(group: "com.inversoft.cleanspeak", name: "cleanspeak-containers", version: "3.34.0", licenses: ["ApacheV2_0"]) {
   workflow {
     fetch {
       cache()

--- a/docker/cleanspeak/cleanspeak-management-interface-mysql/Dockerfile
+++ b/docker/cleanspeak/cleanspeak-management-interface-mysql/Dockerfile
@@ -22,12 +22,12 @@
 # -----------------------------------------------------------------------------
 #
 # Build:
-#   > docker build -t cleanspeak/cleanspeak-management-interface-mysql:3.33.0 .
+#   > docker build -t cleanspeak/cleanspeak-management-interface-mysql:3.34.0 .
 #   > docker build -t cleanspeak/cleanspeak-management-interface-mysql:latest .
 #
 # Run:
 #  > docker run -p 8011:8011 -it cleanspeak/cleanspeak-management-interface-mysql
 #
 
-FROM cleanspeak/cleanspeak-management-interface:3.33.0
+FROM cleanspeak/cleanspeak-management-interface:3.34.0
 ADD --chown=cleanspeak:cleanspeak https://search.maven.org/remotecontent?filepath=com/mysql/mysql-connector-j/8.0.33/mysql-connector-j-8.0.33.jar /usr/local/cleanspeak/cleanspeak-management-interface/web/WEB-INF/lib

--- a/docker/cleanspeak/cleanspeak-management-interface-mysql/Dockerfile
+++ b/docker/cleanspeak/cleanspeak-management-interface-mysql/Dockerfile
@@ -30,4 +30,4 @@
 #
 
 FROM cleanspeak/cleanspeak-management-interface:3.34.0
-ADD --chown=cleanspeak:cleanspeak https://search.maven.org/remotecontent?filepath=com/mysql/mysql-connector-j/8.0.33/mysql-connector-j-8.0.33.jar /usr/local/cleanspeak/cleanspeak-management-interface/web/WEB-INF/lib
+ADD --chown=cleanspeak:cleanspeak https://search.maven.org/remotecontent?filepath=com/mysql/mysql-connector-j/8.0.33/mysql-connector-j-8.0.33.jar /usr/local/cleanspeak/cleanspeak-management-interface/lib

--- a/docker/cleanspeak/cleanspeak-management-interface/Dockerfile
+++ b/docker/cleanspeak/cleanspeak-management-interface/Dockerfile
@@ -28,12 +28,12 @@ ARG TARGETARCH
 RUN printf "Building on ${BUILDPLATFORM} for ${TARGETPLATFORM} (${TARGETARCH})."
 RUN case "${BUILDPLATFORM}" in \
     linux/arm64)\
-        BUILD_JAVA_SUM="2e3c19c1707205c6b90cc04b416e8d83078ed98417d5a69dce3cf7dc0d7cfbca";\
-        BUILD_JAVA_URL="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.3%2B7/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.3_7.tar.gz";\
+        BUILD_JAVA_SUM="eefd3cf3b3dd47ff269fa5b5c10b5e096b163f4e9c1810023abdbc00dc6cc304";\
+        BUILD_JAVA_URL="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1%2B1/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.8.1_1.tar.gz";\
         ;;\
     linux/amd64)\
-        BUILD_JAVA_SUM="81f5bed21077f9fbb04909b50391620c78b9a3c376593c0992934719c0de6b73";\
-        BUILD_JAVA_URL="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.3%2B7/OpenJDK17U-jdk_x64_linux_hotspot_17.0.3_7.tar.gz";\
+        BUILD_JAVA_SUM="c25dfbc334068a48c19c44ce39ad4b8427e309ae1cfa83f23c102e78b8a6dcc0";\
+        BUILD_JAVA_URL="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1%2B1/OpenJDK17U-jdk_x64_linux_hotspot_17.0.8.1_1.tar.gz";\
         ;;\
     *)\
         printf "Unsupported build platform arch: ${BUILDPLATFORM}";\
@@ -42,24 +42,24 @@ RUN case "${BUILDPLATFORM}" in \
     esac \
     && case "${TARGETARCH}" in \
     arm64)\
-        JAVA_SUM="2e3c19c1707205c6b90cc04b416e8d83078ed98417d5a69dce3cf7dc0d7cfbca";\
-        JAVA_URL="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.3%2B7/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.3_7.tar.gz";\
+        JAVA_SUM="eefd3cf3b3dd47ff269fa5b5c10b5e096b163f4e9c1810023abdbc00dc6cc304";\
+        JAVA_URL="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1%2B1/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.8.1_1.tar.gz";\
         ;;\
     arm)\
-        JAVA_SUM="d76c462f44c9f306a0fe4468a0218a261ab152f358a8fb55ec80865bf35e2c41";\
-        JAVA_URL="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.3%2B7/OpenJDK17U-jdk_arm_linux_hotspot_17.0.3_7.tar.gz";\
+        JAVA_SUM="b1f1d8b7fcb159a0a8029b6c3106d1d16207cecbb2047f9a4be2a64d29897da5";\
+        JAVA_URL="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1%2B1/OpenJDK17U-jdk_arm_linux_hotspot_17.0.8.1_1.tar.gz";\
         ;;\
     ppc64le)\
-        JAVA_SUM="a04587018c9719dca21073f19d56b335c4985f41afe7d99b24852c1a94b917e5";\
-        JAVA_URL="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.3%2B7/OpenJDK17U-jdk_ppc64le_linux_hotspot_17.0.3_7.tar.gz";\
+        JAVA_SUM="00a4c07603d0218cd678461b5b3b7e25b3253102da4022d31fc35907f21a2efd";\
+        JAVA_URL="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1%2B1/OpenJDK17U-jdk_ppc64le_linux_hotspot_17.0.8.1_1.tar.gz";\
         ;;\
     s390x)\
-        JAVA_SUM="d9456cdf9719f9d8a11f26b2dd176cd6a8478d96ced09396765c7473482bc7f1";\
-        JAVA_URL="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.3%2B7/OpenJDK17U-jdk_s390x_linux_hotspot_17.0.3_7.tar.gz";\
+        JAVA_SUM="ffacba69c6843d7ca70d572489d6cc7ab7ae52c60f0852cedf4cf0d248b6fc37";\
+        JAVA_URL="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1%2B1/OpenJDK17U-jdk_s390x_linux_hotspot_17.0.8.1_1.tar.gz";\
         ;;\
     amd64)\
-        JAVA_SUM="81f5bed21077f9fbb04909b50391620c78b9a3c376593c0992934719c0de6b73";\
-        JAVA_URL="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.3%2B7/OpenJDK17U-jdk_x64_linux_hotspot_17.0.3_7.tar.gz";\
+        JAVA_SUM="c25dfbc334068a48c19c44ce39ad4b8427e309ae1cfa83f23c102e78b8a6dcc0";\
+        JAVA_URL="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1%2B1/OpenJDK17U-jdk_x64_linux_hotspot_17.0.8.1_1.tar.gz";\
         ;;\
     *)\
         printf "Unsupported arch: ${TARGETARCH}";\

--- a/docker/cleanspeak/cleanspeak-management-interface/Dockerfile
+++ b/docker/cleanspeak/cleanspeak-management-interface/Dockerfile
@@ -94,7 +94,7 @@ RUN apt-get update \
     && apt-get -y clean \
     && rm -rf /var/lib/apt/lists \
     && useradd -d /usr/local/cleanspeak -U cleanspeak
-COPY --from=build /opt/openjdk /opt/openjdk
+COPY --chown=cleanspeak:cleanspeak --from=build /opt/openjdk /opt/openjdk
 COPY --chown=cleanspeak:cleanspeak --from=build /usr/local/cleanspeak /usr/local/cleanspeak
 
 ###### Connect the log file to stdout #############################################################
@@ -110,4 +110,4 @@ USER cleanspeak
 ENV CLEANSPEAK_USE_GLOBAL_JAVA=1
 ENV JAVA_HOME=/opt/openjdk
 ENV PATH=$PATH:$JAVA_HOME/bin
-CMD ["/usr/local/cleanspeak/cleanspeak-management-interface/apache-tomcat/bin/catalina.sh", "run"]
+CMD ["/usr/local/cleanspeak/cleanspeak-management-interface/bin/start.sh"]

--- a/docker/cleanspeak/cleanspeak-management-interface/Dockerfile
+++ b/docker/cleanspeak/cleanspeak-management-interface/Dockerfile
@@ -13,7 +13,7 @@
 #  > docker run -p 8011:8011 -it cleanspeak/cleanspeak-management-interface
 #
 # Publish:
-#   > docker push cleanspeak/cleanspeak-management-interface:3.33.0
+#   > docker push cleanspeak/cleanspeak-management-interface:3.34.0
 #   > docker push cleanspeak/cleanspeak-management-interface:latest
 #
 
@@ -21,7 +21,7 @@
 FROM --platform=$BUILDPLATFORM ubuntu:jammy as build
 
 ARG BUILDPLATFORM
-ARG CLEANSPEAK_VERSION=3.33.0
+ARG CLEANSPEAK_VERSION=3.34.0
 ARG JDK_MODULES=java.base,java.compiler,java.desktop,java.instrument,java.logging,java.management,java.naming,java.rmi,java.security.jgss,java.security.sasl,java.scripting,java.sql,java.xml.crypto,jdk.attach,jdk.crypto.ec,jdk.dynalink,jdk.jcmd,jdk.jdi,jdk.localedata,jdk.jpackage,jdk.unsupported,jdk.zipfs
 ARG TARGETPLATFORM
 ARG TARGETARCH

--- a/docker/cleanspeak/cleanspeak-management-interface/Dockerfile
+++ b/docker/cleanspeak/cleanspeak-management-interface/Dockerfile
@@ -94,7 +94,7 @@ RUN apt-get update \
     && apt-get -y clean \
     && rm -rf /var/lib/apt/lists \
     && useradd -d /usr/local/cleanspeak -U cleanspeak
-COPY --chown=cleanspeak:cleanspeak --from=build /opt/openjdk /opt/openjdk
+COPY --from=build /opt/openjdk /opt/openjdk
 COPY --chown=cleanspeak:cleanspeak --from=build /usr/local/cleanspeak /usr/local/cleanspeak
 
 ###### Connect the log file to stdout #############################################################

--- a/docker/cleanspeak/cleanspeak-webservice-mysql/Dockerfile
+++ b/docker/cleanspeak/cleanspeak-webservice-mysql/Dockerfile
@@ -30,4 +30,4 @@
 #
 
 FROM cleanspeak/cleanspeak-webservice:3.34.0
-ADD --chown=cleanspeak:cleanspeak https://search.maven.org/remotecontent?filepath=com/mysql/mysql-connector-j/8.0.33/mysql-connector-j-8.0.33.jar /usr/local/cleanspeak/cleanspeak-webservice/web/WEB-INF/lib
+ADD --chown=cleanspeak:cleanspeak https://search.maven.org/remotecontent?filepath=com/mysql/mysql-connector-j/8.0.33/mysql-connector-j-8.0.33.jar /usr/local/cleanspeak/cleanspeak-webservice/lib

--- a/docker/cleanspeak/cleanspeak-webservice-mysql/Dockerfile
+++ b/docker/cleanspeak/cleanspeak-webservice-mysql/Dockerfile
@@ -22,12 +22,12 @@
 # -----------------------------------------------------------------------------
 #
 # Build:
-#   > docker build -t cleanspeak/cleanspeak-webservice-mysql:3.33.0 .
+#   > docker build -t cleanspeak/cleanspeak-webservice-mysql:3.34.0 .
 #   > docker build -t cleanspeak/cleanspeak-webservice-mysql:latest .
 #
 # Run:
 #  > docker run -p 8001:8001 -it cleanspeak/cleanspeak-webservice-mysql
 #
 
-FROM cleanspeak/cleanspeak-webservice:3.33.0
+FROM cleanspeak/cleanspeak-webservice:3.34.0
 ADD --chown=cleanspeak:cleanspeak https://search.maven.org/remotecontent?filepath=com/mysql/mysql-connector-j/8.0.33/mysql-connector-j-8.0.33.jar /usr/local/cleanspeak/cleanspeak-webservice/web/WEB-INF/lib

--- a/docker/cleanspeak/cleanspeak-webservice/Dockerfile
+++ b/docker/cleanspeak/cleanspeak-webservice/Dockerfile
@@ -13,7 +13,7 @@
 #  > docker run -p 8001:8001 -it cleanspeak/cleanspeak-webservice
 #
 # Publish:
-#   > docker push cleanspeak/cleanspeak-webservice:3.33.0
+#   > docker push cleanspeak/cleanspeak-webservice:3.34.0
 #   > docker push cleanspeak/cleanspeak-webservice:latest
 #
 
@@ -21,7 +21,7 @@
 FROM --platform=$BUILDPLATFORM ubuntu:jammy as build
 
 ARG BUILDPLATFORM
-ARG CLEANSPEAK_VERSION=3.33.0
+ARG CLEANSPEAK_VERSION=3.34.0
 ARG JDK_MODULES=java.base,java.compiler,java.desktop,java.instrument,java.logging,java.management,java.naming,java.rmi,java.security.jgss,java.security.sasl,java.scripting,java.sql,java.xml.crypto,jdk.attach,jdk.crypto.ec,jdk.dynalink,jdk.jcmd,jdk.jdi,jdk.localedata,jdk.jpackage,jdk.unsupported,jdk.zipfs
 ARG TARGETPLATFORM
 ARG TARGETARCH

--- a/docker/cleanspeak/cleanspeak-webservice/Dockerfile
+++ b/docker/cleanspeak/cleanspeak-webservice/Dockerfile
@@ -28,12 +28,12 @@ ARG TARGETARCH
 RUN printf "Building on ${BUILDPLATFORM} for ${TARGETPLATFORM} (${TARGETARCH})."
 RUN case "${BUILDPLATFORM}" in \
     linux/arm64)\
-        BUILD_JAVA_SUM="2e3c19c1707205c6b90cc04b416e8d83078ed98417d5a69dce3cf7dc0d7cfbca";\
-        BUILD_JAVA_URL="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.3%2B7/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.3_7.tar.gz";\
+        BUILD_JAVA_SUM="eefd3cf3b3dd47ff269fa5b5c10b5e096b163f4e9c1810023abdbc00dc6cc304";\
+        BUILD_JAVA_URL="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1%2B1/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.8.1_1.tar.gz";\
         ;;\
     linux/amd64)\
-        BUILD_JAVA_SUM="81f5bed21077f9fbb04909b50391620c78b9a3c376593c0992934719c0de6b73";\
-        BUILD_JAVA_URL="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.3%2B7/OpenJDK17U-jdk_x64_linux_hotspot_17.0.3_7.tar.gz";\
+        BUILD_JAVA_SUM="c25dfbc334068a48c19c44ce39ad4b8427e309ae1cfa83f23c102e78b8a6dcc0";\
+        BUILD_JAVA_URL="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1%2B1/OpenJDK17U-jdk_x64_linux_hotspot_17.0.8.1_1.tar.gz";\
         ;;\
     *)\
         printf "Unsupported build platform arch: ${BUILDPLATFORM}";\
@@ -42,24 +42,24 @@ RUN case "${BUILDPLATFORM}" in \
     esac \
     && case "${TARGETARCH}" in \
     arm64)\
-        JAVA_SUM="2e3c19c1707205c6b90cc04b416e8d83078ed98417d5a69dce3cf7dc0d7cfbca";\
-        JAVA_URL="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.3%2B7/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.3_7.tar.gz";\
+        JAVA_SUM="eefd3cf3b3dd47ff269fa5b5c10b5e096b163f4e9c1810023abdbc00dc6cc304";\
+        JAVA_URL="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1%2B1/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.8.1_1.tar.gz";\
         ;;\
     arm)\
-        JAVA_SUM="d76c462f44c9f306a0fe4468a0218a261ab152f358a8fb55ec80865bf35e2c41";\
-        JAVA_URL="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.3%2B7/OpenJDK17U-jdk_arm_linux_hotspot_17.0.3_7.tar.gz";\
+        JAVA_SUM="b1f1d8b7fcb159a0a8029b6c3106d1d16207cecbb2047f9a4be2a64d29897da5";\
+        JAVA_URL="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1%2B1/OpenJDK17U-jdk_arm_linux_hotspot_17.0.8.1_1.tar.gz";\
         ;;\
     ppc64le)\
-        JAVA_SUM="a04587018c9719dca21073f19d56b335c4985f41afe7d99b24852c1a94b917e5";\
-        JAVA_URL="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.3%2B7/OpenJDK17U-jdk_ppc64le_linux_hotspot_17.0.3_7.tar.gz";\
+        JAVA_SUM="00a4c07603d0218cd678461b5b3b7e25b3253102da4022d31fc35907f21a2efd";\
+        JAVA_URL="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1%2B1/OpenJDK17U-jdk_ppc64le_linux_hotspot_17.0.8.1_1.tar.gz";\
         ;;\
     s390x)\
-        JAVA_SUM="d9456cdf9719f9d8a11f26b2dd176cd6a8478d96ced09396765c7473482bc7f1";\
-        JAVA_URL="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.3%2B7/OpenJDK17U-jdk_s390x_linux_hotspot_17.0.3_7.tar.gz";\
+        JAVA_SUM="ffacba69c6843d7ca70d572489d6cc7ab7ae52c60f0852cedf4cf0d248b6fc37";\
+        JAVA_URL="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1%2B1/OpenJDK17U-jdk_s390x_linux_hotspot_17.0.8.1_1.tar.gz";\
         ;;\
     amd64)\
-        JAVA_SUM="81f5bed21077f9fbb04909b50391620c78b9a3c376593c0992934719c0de6b73";\
-        JAVA_URL="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.3%2B7/OpenJDK17U-jdk_x64_linux_hotspot_17.0.3_7.tar.gz";\
+        JAVA_SUM="c25dfbc334068a48c19c44ce39ad4b8427e309ae1cfa83f23c102e78b8a6dcc0";\
+        JAVA_URL="https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.8.1%2B1/OpenJDK17U-jdk_x64_linux_hotspot_17.0.8.1_1.tar.gz";\
         ;;\
     *)\
         printf "Unsupported arch: ${TARGETARCH}";\

--- a/docker/cleanspeak/cleanspeak-webservice/Dockerfile
+++ b/docker/cleanspeak/cleanspeak-webservice/Dockerfile
@@ -94,7 +94,7 @@ RUN apt-get update \
     && apt-get -y clean \
     && rm -rf /var/lib/apt/lists \
     && useradd -d /usr/local/cleanspeak -U cleanspeak
-COPY --from=build /opt/openjdk /opt/openjdk
+COPY --chown=cleanspeak:cleanspeak --from=build /opt/openjdk /opt/openjdk
 COPY --chown=cleanspeak:cleanspeak --from=build /usr/local/cleanspeak /usr/local/cleanspeak
 
 ###### Connect the log file to stdout #############################################################
@@ -110,4 +110,4 @@ USER cleanspeak
 ENV CLEANSPEAK_USE_GLOBAL_JAVA=1
 ENV JAVA_HOME=/opt/openjdk
 ENV PATH=$PATH:$JAVA_HOME/bin
-CMD ["/usr/local/cleanspeak/cleanspeak-webservice/apache-tomcat/bin/catalina.sh", "run"]
+CMD ["/usr/local/cleanspeak/cleanspeak-webservice/bin/start.sh"]

--- a/docker/cleanspeak/cleanspeak-webservice/Dockerfile
+++ b/docker/cleanspeak/cleanspeak-webservice/Dockerfile
@@ -94,7 +94,7 @@ RUN apt-get update \
     && apt-get -y clean \
     && rm -rf /var/lib/apt/lists \
     && useradd -d /usr/local/cleanspeak -U cleanspeak
-COPY --chown=cleanspeak:cleanspeak --from=build /opt/openjdk /opt/openjdk
+COPY --from=build /opt/openjdk /opt/openjdk
 COPY --chown=cleanspeak:cleanspeak --from=build /usr/local/cleanspeak /usr/local/cleanspeak
 
 ###### Connect the log file to stdout #############################################################

--- a/docker/cleanspeak/release-trigger
+++ b/docker/cleanspeak/release-trigger
@@ -1,3 +1,3 @@
-version=3.33.0
+version=3.34.0
 preRelease=false
 tagSuffix=


### PR DESCRIPTION
1. Tomcat removal
2. Startup scripts make changes to openjdk stuff that the cleanspeak user needs perms to mess with. One could argue this could/should be backed into the Docker image to preserve immutability.

https://github.com/CleanSpeak/cleanspeak-internal-issues/issues/41